### PR TITLE
Make the lint tool emit a pointer to the docs.

### DIFF
--- a/lint/lint.py
+++ b/lint/lint.py
@@ -227,27 +227,46 @@ def output_error_count(error_count):
 
 def main():
     error_count = defaultdict(int)
+    last = None
 
-    def run_lint(path, fn, *args):
+    def run_lint(path, fn, last, *args):
         errors = whitelist_errors(path, fn(path, *args))
+        if errors:
+            last = (errors[-1][0], path)
+
         output_errors(errors)
         for error_type, error, line in errors:
             error_count[error_type] += 1
+        return last
 
     for path in iter_files():
         abs_path = os.path.join(repo_root, path)
         if not os.path.exists(path):
             continue
         for path_fn in path_lints:
-            run_lint(path, path_fn)
+            last = run_lint(path, path_fn, last)
 
         if not os.path.isdir(abs_path):
             with open(abs_path) as f:
                 for file_fn in file_lints:
-                    run_lint(path, file_fn, f)
+                    last = run_lint(path, file_fn, last, f)
                     f.seek(0)
 
     output_error_count(error_count)
+    if error_count:
+        print
+        print "You must fix all errors; for details on how to fix them, see"
+        print "https://github.com/w3c/web-platform-tests/blob/master/docs/lint-tool.md"
+        print
+        print "However, instead of fixing a particular error, it's sometimes"
+        print "OK to add a line to the lint.whitelist file in the root of the"
+        print "web-platform-tests directory to make the lint tool ignore it."
+        print
+        print "For example, to make the lint tool ignore all '%s'" % last[0]
+        print "errors in the %s file," %  last[1]
+        print "you could add the following line to the lint.whitelist file."
+        print
+        print "%s:%s" % (last[0], last[1])
     return sum(error_count.itervalues())
 
 path_lints = [check_path_length]


### PR DESCRIPTION
If the lint tool finds any errors, this causes it to emit a message with the Web URL for the lint-tool docs at https://github.com/w3c/web-platform-tests/blob/master/docs/lint-tool.md and to also emit a statement that it's sometimes OK to whitelist an error, and finally to emit a brief explanation of how to whitelist errors.