### PR TITLE
update runner to display and report count of tests NOTRUN

### DIFF
--- a/runner/index.html
+++ b/runner/index.html
@@ -121,6 +121,7 @@
             <th>Failed
             <th>Timeouts
             <th>Errors
+            <th>Not Run</th>
           </tr>
         </thead>
         <tbody>
@@ -129,6 +130,7 @@
             <td class='FAIL'>0
             <td class='TIMEOUT'>0
             <td class='ERROR'>0
+            <td class='NOTRUN'>0
           </tr>
         </tbody>
       </table>

--- a/runner/runner.css
+++ b/runner/runner.css
@@ -153,6 +153,10 @@ td.TIMEOUT {
     color:  #f6bb42;
 }
 
+td.NOTRUN {
+    color:  #00c;
+}
+
 td.ERROR {
     color: #da4453;
     font-weight: bold;

--- a/runner/runner.js
+++ b/runner/runner.js
@@ -145,7 +145,8 @@ VisualOutput.prototype = {
         this.result_count = {"PASS":0,
                              "FAIL":0,
                              "ERROR":0,
-                             "TIMEOUT":0};
+                             "TIMEOUT":0,
+                             "NOTRUN":0};
         for (var p in this.result_count) {
             if (this.result_count.hasOwnProperty(p)) {
                 this.elem.querySelector("td." + p).textContent = 0;
@@ -183,12 +184,19 @@ VisualOutput.prototype = {
         var subtest_pass_count = subtests.reduce(function(prev, current) {
             return (current.status === "PASS") ? prev + 1 : prev;
         }, 0);
+
+        var subtest_notrun_count = subtests.reduce(function(prev, current) {
+            return (current.status === "NOTRUN") ? prev +1 : prev;
+        }, 0);
+
         var subtests_count = subtests.length;
 
         var test_status;
         if (subtest_pass_count === subtests_count &&
             (status == "OK" || status == "PASS")) {
             test_status = "PASS";
+        } else if (subtest_notrun_count == subtests_count) {
+            test_status = "NOTRUN";
         } else if (subtests_count > 0 && status === "OK") {
             test_status = "FAIL";
         } else {
@@ -225,7 +233,7 @@ VisualOutput.prototype = {
             }
         }
 
-        var status_arr = ["PASS", "FAIL", "ERROR", "TIMEOUT"];
+        var status_arr = ["PASS", "FAIL", "ERROR", "TIMEOUT", "NOTRUN"];
         for (var i = 0; i < status_arr.length; i++) {
             this.elem.querySelector("td." + status_arr[i]).textContent = this.result_count[status_arr[i]];
         }
@@ -707,7 +715,7 @@ function setup() {
 }
 
 window.completion_callback = function(tests, status) {
-    var harness_status_map = {0:"OK", 1:"ERROR", 2:"TIMEOUT"};
+    var harness_status_map = {0:"OK", 1:"ERROR", 2:"TIMEOUT", 3:"NOTRUN"};
     var subtest_status_map = {0:"PASS", 1:"FAIL", 2:"TIMEOUT", 3:"NOTRUN"};
 
     // this ugly hack is because IE really insists on holding on to the objects it creates in


### PR DESCRIPTION
This commit adds collection of "NOT RUN" results to the test runner.

Sometimes this is the only appropriate result.  For example, Content Security Policy specifies certain behaviors around handling of plugin content.  If a user agent doesn't support that plugin / media type, the test doesn't pass or fail, it is just not run.  It may be that there is no way for a given user agent to support that plugin content (e.g. Flash with Safari for iOS) or it may be that additional configuration is required before a result can be obtained (e.g. installing Flash or Java plugins for Firefox).  Reporting the tests explicitly as NOT RUN gives an indication of this state that is more accurate than previous behavior of reporting such tests as failing.