### PR TITLE
Add support for filtering displayed test results.

### DIFF
--- a/runner/index.html
+++ b/runner/index.html
@@ -117,20 +117,34 @@
       <table class='table'>
         <thead>
           <tr>
-            <th>Passed
-            <th>Failed
-            <th>Timeouts
-            <th>Errors
+            <th></th>
+            <th>Passed</th>
+            <th>Failed</th>
+            <th>Timeouts</th>
+            <th>Errors</th>
             <th>Not Run</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td class='PASS'>0
-            <td class='FAIL'>0
-            <td class='TIMEOUT'>0
-            <td class='ERROR'>0
-            <td class='NOTRUN'>0
+            <td></td>
+            <td class='PASS'>0</td>
+            <td class='FAIL'>0</td>
+            <td class='TIMEOUT'>0</td>
+            <td class='ERROR'>0</td>
+            <td class='NOTRUN'>0</td>
+          </tr>
+           <tr>
+            <td>
+              <label>
+                Display:
+              </label>
+              </td>
+            <td><input type=checkbox class="result-display-filter" value="PASS" checked></td>
+            <td><input type=checkbox class="result-display-filter" value="FAIL" checked></td>
+            <td><input type=checkbox class="result-display-filter" value="TIMEOUT" checked></td>
+            <td><input type=checkbox class="result-display-filter" value="ERROR" checked></td>
+            <td><input type=checkbox class="result-display-filter" value="NOTRUN" checked></td>
           </tr>
         </tbody>
       </table>

--- a/runner/runner.js
+++ b/runner/runner.js
@@ -138,6 +138,18 @@ function VisualOutput(elem, runner) {
     this.runner.start_callbacks.push(this.on_start.bind(this));
     this.runner.result_callbacks.push(this.on_result.bind(this));
     this.runner.done_callbacks.push(this.on_done.bind(this));
+
+    this.display_filter_state = {};
+
+    var visual_output = this;
+    var display_filter_inputs = this.elem.querySelectorAll(".result-display-filter");
+    for (var i = 0; i < display_filter_inputs.length; ++i) {
+        var display_filter_input = display_filter_inputs[i];
+        this.display_filter_state[display_filter_input.value] = display_filter_input.checked;
+        display_filter_input.addEventListener("change", function(e) {
+            visual_output.apply_display_filter(e.target.value, e.target.checked);
+        })
+    }
 }
 
 VisualOutput.prototype = {
@@ -238,6 +250,7 @@ VisualOutput.prototype = {
             this.elem.querySelector("td." + status_arr[i]).textContent = this.result_count[status_arr[i]];
         }
 
+        this.apply_display_filter_to_result_row(row, this.display_filter_state[test_status]);
         this.results_table.tBodies[0].appendChild(row);
         this.update_meter(this.runner.progress(), this.runner.results.count(), this.runner.test_count());
     },
@@ -295,8 +308,19 @@ VisualOutput.prototype = {
         this.meter.setAttribute("aria-valuenow", count);
         this.meter.setAttribute("aria-valuemax", total);
         this.meter.textContent = this.meter.style.width = (progress * 100).toFixed(1) + "%";
-    }
+    },
 
+    apply_display_filter: function(test_status, display_state) {
+        this.display_filter_state[test_status] = display_state;
+        var result_cells = this.elem.querySelectorAll(".results > table tr td." + test_status);
+        for (var i = 0; i < result_cells.length; ++i) {
+            this.apply_display_filter_to_result_row(result_cells[i].parentNode, display_state)
+        }
+    },
+
+    apply_display_filter_to_result_row: function(result_row, display_state) {
+        result_row.style.display = display_state ? "" : "none";
+    }
 };
 
 function ManualUI(elem, runner) {


### PR DESCRIPTION
Simple filtering of displayed results by their outcome.

The filter is also being applied on-the-fly (as the test results are coming in.)

![image](https://cloud.githubusercontent.com/assets/7973657/8807418/bd3773f4-2fdc-11e5-96ee-e01541a39546.png)

Few potential issues worth discussing:
* The test name DIV sometimes changes height if test name is too long (moves everything below it up'n'down)
* The summary should maybe be displayed before starting to run the tests (to be able to select filters)
* Download JSON results should maybe be renamed to "Download **all** results as JSON"

@jgraham 