### PR TITLE
Check clashing test filenames

### DIFF
--- a/manifest/sourcefile.py
+++ b/manifest/sourcefile.py
@@ -278,6 +278,9 @@ class SourceFile(object):
         graph (i.e. if it contains any <link rel=[mis]match>"""
         return bool(self.references)
 
+    def is_test(self):
+        return self.name_is_manual or self.name_is_worker or self.name_is_webdriver or self.content_is_testharness or self.content_is_ref_node
+
     def manifest_items(self):
         """List of manifest items corresponding to the file. There is typically one
         per test, but in the case of reftests a node may have corresponding manifest
@@ -313,3 +316,4 @@ class SourceFile(object):
             rv = []
 
         return rv
+


### PR DESCRIPTION
Following discussions in https://github.com/w3c/web-platform-tests/issues/2327, adding lint check for test files whose filenames without extension are the same.
This causes issues in WebKit since test results would clash for those tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/40)
<!-- Reviewable:end -->
