### PR TITLE
Ensure that MANIFEST.json use UNIX file format.

### DIFF
--- a/manifest/manifest.py
+++ b/manifest/manifest.py
@@ -374,6 +374,6 @@ def load(tests_root, manifest):
 
 
 def write(manifest, manifest_path):
-    with open(manifest_path, "w") as f:
+    with open(manifest_path, "wb") as f:
         json.dump(manifest.to_json(), f, sort_keys=True, indent=2, separators=(',', ': '))
         f.write("\n")


### PR DESCRIPTION
Adding 'b' to the file mode ensures the file uses UNIX file format even on Windows.

Note that, this change isn't compatible with Python 3. In Python 3, we need to add `newline='\n'` instead of specifying binary mode.