### PR TITLE
Fixed library search paths

### DIFF
--- a/manifest/sourcefile.py
+++ b/manifest/sourcefile.py
@@ -1,3 +1,4 @@
+import imp
 import os
 from six.moves.urllib.parse import urljoin
 from fnmatch import fnmatch
@@ -5,6 +6,9 @@ try:
     from xml.etree import cElementTree as ElementTree
 except ImportError:
     from xml.etree import ElementTree
+
+here = os.path.dirname(__file__)
+localpaths = imp.load_source("localpaths", os.path.abspath(os.path.join(here, os.pardir, "localpaths.py")))
 
 import html5lib
 


### PR DESCRIPTION
Sourcefile.py was looking for html5lib, but did not know about
localpaths so was unable to resolve the import when called from the
command line in the top level WPT folder via the manifest python script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/69)
<!-- Reviewable:end -->
