### PR TITLE
Delay the SourceFile import in lint.

### DIFF
--- a/lint/lint.py
+++ b/lint/lint.py
@@ -12,8 +12,6 @@ from collections import defaultdict
 from six import iteritems
 from six.moves import range
 
-from manifest.sourcefile import SourceFile
-
 here = os.path.abspath(os.path.split(__file__)[0])
 
 ERROR_MSG = """You must fix all errors; for details on how to fix them, see
@@ -155,6 +153,8 @@ def check_regexp_line(repo_root, path, f):
     return errors
 
 def check_parsed(repo_root, path, f):
+    from manifest.sourcefile import SourceFile
+
     source_file = SourceFile(repo_root, path, "/")
 
     errors = []


### PR DESCRIPTION
Due to the way this code is used in web-platform-tests, the localpaths
import is required in that context, but not in tests in this repository.

This introduces the unfortunate problem that check_parsed() can only be
called through main(), but this is the fastest approach I can think of that
will allow the tests in this repository to keep working, while also
ensuring the lint script in web-platform-tests works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/73)
<!-- Reviewable:end -->
