### PR TITLE
Avoid duplicate certificate serial numbers

### DIFF
--- a/sslutils/openssl.py
+++ b/sslutils/openssl.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import random
 import shutil
 import subprocess
 import tempfile
@@ -251,7 +252,7 @@ class OpenSSLEnvironment(object):
         with open(path("index.txt"), "w"):
             pass
         with open(path("serial"), "w") as f:
-            f.write("01")
+            f.write(str(random.randint(0, 1000000)))
 
         self.path = path
 


### PR DESCRIPTION
Use random starting certificate serial number on first run instead of a constant one. Switching between different local copies will no longer cause irrecoverable browser errors due to re-use of certificate serial numbers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/77)
<!-- Reviewable:end -->
