### PR TITLE
Fixed logo and manual UI position

### DIFF
--- a/runner/index.html
+++ b/runner/index.html
@@ -12,7 +12,7 @@
   <div class="container">
     <div class="navbar-header">
       <a class="navbar-brand" href="#">
-        <img src='logo.svg' width='50' height='50' alt='Logo for the WPT Runner'>
+        <img src='logo.svg' width='50' height='50' alt='Logo for the WPT Runner' style="float: left">
         Web Platform Tests Runner
       </a>
     </div>

--- a/runner/index.html
+++ b/runner/index.html
@@ -12,7 +12,7 @@
   <div class="container">
     <div class="navbar-header">
       <a class="navbar-brand" href="#">
-        <img src='logo.svg' width='50' height='50' alt='Logo for the WPT Runner' style="float: left">
+        <img src='logo.svg' width='50' height='50' alt='Logo for the WPT Runner'>
         Web Platform Tests Runner
       </a>
     </div>

--- a/runner/runner.css
+++ b/runner/runner.css
@@ -90,7 +90,8 @@ html.done section + section {
 
 #manualUI {
     position: fixed;
-    top: 100px;
+    z-index: 2000;
+    top: -20px;
     left: 0;
     right: 0;
     display: block;

--- a/runner/runner.css
+++ b/runner/runner.css
@@ -122,6 +122,10 @@ body {
     max-width: 800px;
 }
 
+.navbar-brand > img {
+    display: inline;
+}
+
 .navbar-inverse .navbar-brand {
     color: #fff;
 }


### PR DESCRIPTION
The logo was not floating left so the header text did not display in the
navbar (issue #80)

The manualUI block was too tall when running reftests.  This caused the
stop / pause buttons to be behind the dialog such that they could not be
selected without resizing the window (issue #78)

With these changes the UI header now looks like this:

![screenshot 2016-06-12 at 11 31 13](https://cloud.githubusercontent.com/assets/520688/15992446/4f7cab88-3092-11e6-82f0-c15278844042.png)

and the reftest dialog looks like this:

![screenshot 2016-06-12 at 11 30 46](https://cloud.githubusercontent.com/assets/520688/15992450/5b9d2ece-3092-11e6-8496-18a71a016db7.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/81)
<!-- Reviewable:end -->
