### PR TITLE
Ensure serial number has even number of digits

### DIFF
--- a/sslutils/openssl.py
+++ b/sslutils/openssl.py
@@ -252,7 +252,7 @@ class OpenSSLEnvironment(object):
         with open(path("index.txt"), "w"):
             pass
         with open(path("serial"), "w") as f:
-            serial = str(random.randint(0, 1000000))
+            serial = "%x" % random.randint(0, 1000000)
             if len(serial) % 2:
                 serial = "0" + serial
             f.write(serial)

--- a/sslutils/openssl.py
+++ b/sslutils/openssl.py
@@ -252,7 +252,10 @@ class OpenSSLEnvironment(object):
         with open(path("index.txt"), "w"):
             pass
         with open(path("serial"), "w") as f:
-            f.write(str(random.randint(0, 1000000)))
+            serial = str(random.randint(0, 1000000))
+            if len(serial) % 2:
+                serial = "0" + serial
+            f.write(serial)
 
         self.path = path
 


### PR DESCRIPTION
OpenSSL requires that the serial number contain an even number of digits. The change in https://github.com/w3c/wpt-tools/commit/b388d6b14df8acc3fad070c74b435cd7aff056d1 did not maintain this property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/85)
<!-- Reviewable:end -->
