### PR TITLE
Add a lint to check that open() and file() calls in Python specify a mode.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E128,E221,E226,E231,E251,E265,E302,E303,E402,E901,F401,F821,F841
+ignore = E128,E129,E221,E226,E231,E251,E265,E302,E303,E402,E901,F401,F821,F841
 max-line-length = 141
 exclude = html5lib,py,pytest,pywebsocket,six,webdriver,wptserve


### PR DESCRIPTION
Authors mistakenly using open() in text mode has caused a number of bugs
on Windows. It is rather hard to lint for correct usage here since
text-vs-binary is situation dependant. However it is quite possible to
lint that the author made some explicit choice in the subset of cases
where raw open() is called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/87)
<!-- Reviewable:end -->
