### PR TITLE
Add support for optional default headers

### DIFF
--- a/serve/serve.py
+++ b/serve/serve.py
@@ -384,9 +384,12 @@ def normalise_config(config, ports):
     for scheme, ports_used in ports.iteritems():
         ports_[scheme] = ports_used
 
+    default_headers = config["default_headers"] if "default_headers" in config else []
+
     return {"host": host,
             "domains": domains,
-            "ports": ports_}
+            "ports": ports_,
+            "default_headers": default_headers}
 
 
 def get_ssl_config(config, external_domains, ssl_environment):


### PR DESCRIPTION
This change adds a new "default_headers" configuration element. 

```json
    "default_headers": [
        ["Cache-Control", "no-cache, no-store"],
        ["Pragma", "no-cache"]
    ],
```

The work being done here is merely to pass-thru the "default_headers" setting to wptserve. A modification to wptserve to read the new setting is pending on https://github.com/w3c/wptserve/pull/88. From that pull request's description:

> Default headers are useful in setting the default cache policy for wptserve when serving test files for Internet Explorer and Edge in dev and test environments, so that test files are not inadvertently cached between runs. This prevents "F5-refresh" headaches when a developer makes changes to the tests locally, and prevents leftover state on shared machines (which may need to run multiple versions of the tests) from affecting subsequent test runs.