### PR TITLE
Import localpaths in __init__, avoiding the need to import elsewhere

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from . import localpaths as _localpaths

--- a/lint/lint.py
+++ b/lint/lint.py
@@ -12,7 +12,7 @@ import sys
 
 from collections import defaultdict
 
-from .. import localpaths
+from ..localpaths import repo_root
 
 from manifest.sourcefile import SourceFile
 from six import iteritems
@@ -355,7 +355,6 @@ def parse_args():
     return parser.parse_args()
 
 def main():
-    repo_root = localpaths.repo_root
     args = parse_args()
     paths = args.paths if args.paths else all_git_paths(repo_root)
     return lint(repo_root, paths, args.json)

--- a/manifest/sourcefile.py
+++ b/manifest/sourcefile.py
@@ -7,9 +7,6 @@ try:
 except ImportError:
     from xml.etree import ElementTree
 
-here = os.path.dirname(__file__)
-localpaths = imp.load_source("localpaths", os.path.abspath(os.path.join(here, os.pardir, "localpaths.py")))
-
 import html5lib
 
 from . import vcs

--- a/manifest/update.py
+++ b/manifest/update.py
@@ -10,7 +10,6 @@ from .log import get_logger
 from .tree import GitTree, NoVCSTree
 
 here = os.path.dirname(__file__)
-localpaths = imp.load_source("localpaths", os.path.abspath(os.path.join(here, os.pardir, "localpaths.py")))
 
 def update(tests_root, url_base, manifest, ignore_local=False):
     if vcs.is_git_repo(tests_root):

--- a/serve/serve.py
+++ b/serve/serve.py
@@ -16,15 +16,13 @@ import uuid
 from collections import defaultdict, OrderedDict
 from multiprocessing import Process, Event
 
-from .. import localpaths
+from ..localpaths import repo_root
 
 import sslutils
 from wptserve import server as wptserve, handlers
 from wptserve import stash
 from wptserve.logger import set_logger
 from mod_pywebsocket import standalone as pywebsocket
-
-repo_root = localpaths.repo_root
 
 def replace_end(s, old, new):
     """


### PR DESCRIPTION
This fixes ./manifest for people who don't have six installed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/112)
<!-- Reviewable:end -->
