### PR TITLE
Ensure manifest tool flags manual HTTPS tests as manual (#123)

### DIFF
--- a/manifest/sourcefile.py
+++ b/manifest/sourcefile.py
@@ -57,7 +57,7 @@ class SourceFile(object):
 
         self.type_flag = None
         if "-" in self.name:
-            self.type_flag = self.name.rsplit("-", 1)[1]
+            self.type_flag = self.name.rsplit("-", 1)[1].split(".")[0]
 
         self.meta_flags = self.name.split(".")[1:]
 

--- a/manifest/tests/test_sourcefile.py
+++ b/manifest/tests/test_sourcefile.py
@@ -36,6 +36,8 @@ def test_name_is_manual():
     manual_tests = [
         "html/test-manual.html",
         "html/test-manual.xhtml",
+        "html/test-manual.https.html",
+        "html/test-manual.https.xhtml"
     ]
 
     for rel_path in manual_tests:


### PR DESCRIPTION
Manifest tool missed the `manual` in `mytest-manual.https.html` and thus incorrectly listed such tests in the automated section of the manifest file.

Commit includes regression test, although note I haven't managed to make pytest run on my computer for the time being. To be checked before merge!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/124)
<!-- Reviewable:end -->
