### PR TITLE
Ensure that any.js templated tests are finished by the .html suffix

### DIFF
--- a/manifest/sourcefile.py
+++ b/manifest/sourcefile.py
@@ -1,4 +1,3 @@
-import imp
 import os
 from six.moves.urllib.parse import urljoin
 from fnmatch import fnmatch
@@ -328,11 +327,11 @@ class SourceFile(object):
         elif self.name_is_multi_global:
             rv = [
                 TestharnessTest(self, replace_end(self.url, ".any.js", ".any.html")),
-                TestharnessTest(self, replace_end(self.url, ".any.js", ".any.worker")),
+                TestharnessTest(self, replace_end(self.url, ".any.js", ".any.worker.html")),
             ]
 
         elif self.name_is_worker:
-            rv = [TestharnessTest(self, replace_end(self.url, ".worker.js", ".worker"))]
+            rv = [TestharnessTest(self, replace_end(self.url, ".worker.js", ".worker.html"))]
 
         elif self.name_is_webdriver:
             rv = [WebdriverSpecTest(self, self.url)]

--- a/manifest/tests/test_sourcefile.py
+++ b/manifest/tests/test_sourcefile.py
@@ -60,7 +60,7 @@ def test_worker():
 
     assert not s.content_is_testharness
 
-    assert items(s) == [("testharness", "/html/test.worker")]
+    assert items(s) == [("testharness", "/html/test.worker.html")]
 
 
 def test_multi_global():
@@ -75,7 +75,7 @@ def test_multi_global():
 
     assert items(s) == [
         ("testharness", "/html/test.any.html"),
-        ("testharness", "/html/test.any.worker"),
+        ("testharness", "/html/test.any.worker.html"),
     ]
 
 

--- a/serve/serve.py
+++ b/serve/serve.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import argparse
 import json
 import os
-import signal
 import socket
 import sys
 import threading
@@ -41,7 +40,7 @@ class WorkersHandler(object):
         return self.handler(request, response)
 
     def handle_request(self, request, response):
-        worker_path = replace_end(request.url_parts.path, ".worker", ".worker.js")
+        worker_path = replace_end(request.url_parts.path, ".worker.html", ".worker.js")
         return """<!doctype html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
@@ -118,7 +117,7 @@ class RoutesBuilder(object):
                           ("*", "/serve.py", handlers.ErrorHandler(404))]
 
         self.static = [
-            ("GET", "*.worker", WorkersHandler()),
+            ("GET", "*.worker.html", WorkersHandler()),
             ("GET", "*.any.html", AnyHtmlHandler()),
             ("GET", "*.any.worker.js", AnyWorkerHandler()),
         ]


### PR DESCRIPTION
WebKit requires tests to finish with some specific prefixes.
Making this modification allows easier execution of *.any.js or *.worker.js tests in WebKit bots

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/126)
<!-- Reviewable:end -->
