### PR TITLE
Add a shortcut into filter_whitelist_errors for the no error case

### DIFF
--- a/lint/lint.py
+++ b/lint/lint.py
@@ -79,6 +79,9 @@ def filter_whitelist_errors(data, path, errors):
     Filter out those errors that are whitelisted in `data`.
     """
 
+    if not errors:
+        return []
+
     whitelisted = [False for item in range(len(errors))]
 
     for file_match, whitelist_errors in iteritems(data):


### PR DESCRIPTION
This is a ~23% improvement on w-p-t's `./lint`, 31 to 24 seconds locally.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/134)

<!-- Reviewable:end -->
