### PR TITLE
Don't bind StashServer to host name if bind_hostname is false.

### DIFF
--- a/serve/serve.py
+++ b/serve/serve.py
@@ -601,7 +601,11 @@ def main():
 
     setup_logger(config["log_level"])
 
-    with stash.StashServer((config["host"], get_port()), authkey=str(uuid.uuid4())):
+    stash_address = None
+    if config["bind_hostname"]:
+        stash_address = (config["host"], get_port())
+
+    with stash.StashServer(stash_address, authkey=str(uuid.uuid4())):
         with get_ssl_environment(config) as ssl_env:
             config_, servers = start(config, ssl_env, build_routes(config["aliases"]), **kwargs)
 


### PR DESCRIPTION
This fixes a bug where even if bind_hostname is set to False the StashServer would still attempt to bind to the hostname.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/143)
<!-- Reviewable:end -->
