### PR TITLE
Remove "basic" logging configuration

### DIFF
--- a/manifest/log.py
+++ b/manifest/log.py
@@ -1,8 +1,12 @@
 import logging
+import sys
 
-logging.basicConfig()
 logger = logging.getLogger("manifest")
 logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter(logging.BASIC_FORMAT, None)
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 def get_logger():
     return logger


### PR DESCRIPTION
This function call has global side-effects on the `logging` module and
is therefor inappropriate for use within utility code.

> ### `logging.basicConfig([**kwargs])`
>
> Does basic configuration for the logging system by creating a
> `StreamHandler` with a default `Formatter` and adding it to the root
> logger. The functions `debug()`, `info()`, `warning(`), `error()` and
> `critical()` will call `basicConfig()` automatically if no handlers
> are defined for the root logger.

source: https://docs.python.org/2/library/logging.html#logging.basicConfig

This should resolve https://github.com/w3c/web-platform-tests/issues/4323

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/155)
<!-- Reviewable:end -->
