### PR TITLE
Runner: Improve UI during manifest generation

### DIFF
--- a/runner/index.html
+++ b/runner/index.html
@@ -128,9 +128,7 @@
 
   <div id="output">
     <div class="summary clearfix">
-      <h4>Progress
-        <span id="manifest">updating and loading test manifest; this may take several minutes</span>
-      </h4>
+      <h4>Progress</h4>
       <div class="progress">
         <div class="progress-bar" role="progressbar"
              aria-valuenow="0" aria-valuemin="0" aria-valuemax="0" style="width: 0">

--- a/runner/runner.css
+++ b/runner/runner.css
@@ -184,17 +184,13 @@ td.ERROR {
     background-color: inherit;
   }
   to {
-    background-color: #ffc;
+    background-color: #f6bb42;
   }
 }
 
-#manifest {
-  padding-left: 6px;
-  padding-right: 6px;
-  font-size: 80%;
-  font-weight: normal;
-  font-style: italic;
-  color: #999;
+.loading-manifest {
+  background-image: none;
+  color: #333;
   animation-duration: 1.5s;
   animation-name: alert_updating;
   animation-iteration-count: infinite;


### PR DESCRIPTION
While running tests, the runner communicates its status via a dynamic
"progress" indicator. During "steady" states such as "testing stopped," and
"testing complete," the concept of "progress" does not apply. In these cases,
the "progress" indicator is re-used to simply display a static text value.

The "test manifest generation" state is another example of a "steady" state.
Prior to this patch, however, it was communicated via a dedicated UI element.
This inconsistency limited the authority of the progress indicator--users
needed to consult two independent UI elements to determine the status of the
test runner.

Re-use the existing convention for "steady" states to communicate when the
application is generating the test manifest. Increase visibility by rendering
the element in this state with a more distinctive background color.

@sideshowbarker I recorded a few gifs to demonstrate, but the compression
scheme in use tends to limit their helpfulness. Sorry about that.

Before:

![gh-1171-before](https://cloud.githubusercontent.com/assets/677252/22665365/841fd714-ec82-11e6-9188-909e5dc2be01.gif)

After:

![gh-1171-after](https://cloud.githubusercontent.com/assets/677252/22665287/3b5ad8bc-ec82-11e6-8be9-b488378b6832.gif)

This is intended to address https://github.com/w3c/web-platform-tests/issues/1171

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/161)
<!-- Reviewable:end -->
