### PR TITLE
[wptserve] Forward keyword args to spawned process

### DIFF
--- a/serve/serve.py
+++ b/serve/serve.py
@@ -259,7 +259,8 @@ class ServerProc(object):
               ssl_config, **kwargs):
         self.proc = Process(target=self.create_daemon,
                             args=(init_func, host, port, paths, routes, bind_hostname,
-                                  external_config, ssl_config))
+                                  external_config, ssl_config),
+                            kwargs=kwargs)
         self.proc.daemon = True
         self.proc.start()
 


### PR DESCRIPTION
This ensures that optional command-line arguments like `--latency` are
available when specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/166)
<!-- Reviewable:end -->
