### PR TITLE
Support long timeouts in WebDriver tests.

### DIFF
--- a/lint/lint.py
+++ b/lint/lint.py
@@ -15,7 +15,7 @@ from . import fnmatch
 from ..localpaths import repo_root
 from ..gitignore.gitignore import PathFilter
 
-from manifest.sourcefile import SourceFile, meta_re
+from manifest.sourcefile import SourceFile, js_meta_re, python_meta_re
 from six import binary_type, iteritems, itervalues
 from six.moves import range
 
@@ -343,7 +343,11 @@ def check_python_ast(repo_root, path, f, css_mode):
 
 broken_metadata = re.compile(b"//\s*META:")
 def check_script_metadata(repo_root, path, f, css_mode):
-    if not path.endswith((".worker.js", ".any.js")):
+    if path.endswith((".worker.js", ".any.js")):
+        meta_re = js_meta_re
+    elif path.endswith(".py"):
+        meta_re = python_meta_re
+    else:
         return []
 
     done = False

--- a/manifest/item.py
+++ b/manifest/item.py
@@ -210,6 +210,23 @@ class WebdriverSpecTest(URLManifestItem):
         URLManifestItem.__init__(self, source_file, url, url_base=url_base, manifest=manifest)
         self.timeout = timeout
 
+    def to_json(self):
+        rv = URLManifestItem.to_json(self)
+        if self.timeout is not None:
+            rv[-1]["timeout"] = self.timeout
+        return rv
+
+    @classmethod
+    def from_json(cls, manifest, tests_root, path, obj, source_files=None):
+        source_file = get_source_file(source_files, tests_root, manifest, path)
+
+        url, extras = obj
+        return cls(source_file,
+                   url,
+                   url_base=manifest.url_base,
+                   timeout=extras.get("timeout"),
+                   manifest=manifest)
+
 
 class SupportFile(ManifestItem):
     item_type = "support"

--- a/manifest/tests/test_sourcefile.py
+++ b/manifest/tests/test_sourcefile.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from six import BytesIO
-from ..sourcefile import SourceFile, read_script_metadata
+from ..sourcefile import SourceFile, read_script_metadata, js_meta_re, python_meta_re
 
 def create(filename, contents=b""):
     assert isinstance(contents, bytes)
@@ -143,7 +143,7 @@ def test_worker_long_timeout():
 importScripts('/resources/testharness.js')
 test()"""
 
-    metadata = list(read_script_metadata(BytesIO(contents)))
+    metadata = list(read_script_metadata(BytesIO(contents), js_meta_re))
     assert metadata == [(b"timeout", b"long")]
 
     s = create("html/test.worker.js", contents=contents)
@@ -151,6 +151,25 @@ test()"""
 
     item_type, items = s.manifest_items()
     assert item_type == "testharness"
+
+    for item in items:
+        assert item.timeout == "long"
+
+
+def test_python_long_timeout():
+    contents = b"""# META: timeout=long
+
+"""
+
+    metadata = list(read_script_metadata(BytesIO(contents),
+                                         python_meta_re))
+    assert metadata == [(b"timeout", b"long")]
+
+    s = create("webdriver/test.py", contents=contents)
+    assert s.name_is_webdriver
+
+    item_type, items = s.manifest_items()
+    assert item_type == "wdspec"
 
     for item in items:
         assert item.timeout == "long"
@@ -186,7 +205,7 @@ def test_multi_global_long_timeout():
 importScripts('/resources/testharness.js')
 test()"""
 
-    metadata = list(read_script_metadata(BytesIO(contents)))
+    metadata = list(read_script_metadata(BytesIO(contents), js_meta_re))
     assert metadata == [(b"timeout", b"long")]
 
     s = create("html/test.any.js", contents=contents)
@@ -212,7 +231,7 @@ test()"""
     (b"""// META: foobar\n""", []),
 ])
 def test_script_metadata(input, expected):
-    metadata = read_script_metadata(BytesIO(input))
+    metadata = read_script_metadata(BytesIO(input), js_meta_re)
     assert list(metadata) == expected
 
 


### PR DESCRIPTION
Use a syntax like in worker tests i.e.
```
 # META: timeout=long
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/172)
<!-- Reviewable:end -->
