### PR TITLE
Add argument to lint for passing whitelist path

### DIFF
--- a/lint/lint.py
+++ b/lint/lint.py
@@ -679,6 +679,8 @@ def parse_args():
                         help="Output markdown")
     parser.add_argument("--css-mode", action="store_true",
                         help="Run CSS testsuite specific lints")
+    parser.add_argument("--whitelist-path", default=None,
+                        help="Optional path for lint.whitelist")
     return parser.parse_args()
 
 
@@ -695,14 +697,20 @@ def main(**kwargs):
     paths = list(kwargs.get("paths") if kwargs.get("paths") else all_filesystem_paths(repo_root))
     if output_format == "markdown":
         setup_logging(True)
-    return lint(repo_root, paths, output_format, kwargs.get("css_mode", False))
+
+    whitelist_path = kwargs.get("whitelist_path", None)
+
+    return lint(repo_root, paths, output_format, kwargs.get("css_mode", False), whitelist_path)
 
 
-def lint(repo_root, paths, output_format, css_mode):
+def lint(repo_root, paths, output_format, css_mode, whitelist_path=None):
     error_count = defaultdict(int)
     last = None
 
-    with open(os.path.join(repo_root, "lint.whitelist")) as f:
+    if not whitelist_path:
+        whitelist_path = os.path.join(repo_root, "lint.whitelist")
+
+    with open(whitelist_path) as f:
         whitelist, ignored_files = parse_whitelist(f)
 
     output_errors = {"json": output_errors_json,

--- a/lint/tests/test_lint.py
+++ b/lint/tests/test_lint.py
@@ -390,7 +390,7 @@ def test_main_with_args():
         sys.argv = ['./lint', 'a', 'b', 'c']
         with _mock_lint('lint', return_value=True) as m:
             lint_mod.main(**vars(parse_args()))
-            m.assert_called_once_with(repo_root, ['a', 'b', 'c'], "normal", False)
+            m.assert_called_once_with(repo_root, ['a', 'b', 'c'], "normal", False, None)
     finally:
         sys.argv = orig_argv
 
@@ -402,6 +402,16 @@ def test_main_no_args():
         with _mock_lint('lint', return_value=True) as m:
             with _mock_lint('all_filesystem_paths', return_value=['foo', 'bar']) as m2:
                 lint_mod.main(**vars(parse_args()))
-                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", False)
+                m.assert_called_once_with(repo_root, ['foo', 'bar'], "normal", False, None)
+    finally:
+        sys.argv = orig_argv
+
+def test_whitelist_path_arg():
+    orig_argv = sys.argv
+    try:
+        sys.argv = ['./lint', 'a', '--whitelist-path', '~/custom/whitelist']
+        with _mock_lint('lint', return_value=True) as m:
+            lint_mod.main(**vars(parse_args()))
+            m.assert_called_once_with(repo_root, ['a'], "normal", False, '~/custom/whitelist')
     finally:
         sys.argv = orig_argv


### PR DESCRIPTION
We're looking to run the linter as a presubmit script in Chromium but since the lint module will live in a separate location from the whitelist, it needs to be passed in as a parameter.

Chromium bug: https://crbug.com/686927

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/202)
<!-- Reviewable:end -->
