### PR TITLE
Minor config-related enhancements

### DIFF
--- a/runner/runner.js
+++ b/runner/runner.js
@@ -2,7 +2,7 @@
 (function() {
 "use strict";
 var runner;
-var testharness_properties = {output:false,
+var testharness_properties = window.testharness_properties || {output:false,
                               timeout_multiplier:1};
 
 function Manifest(path) {
@@ -559,8 +559,8 @@ TestControl.prototype = {
     },
 
     get_testharness_settings: function() {
-        return {timeout_multiplier: parseFloat(this.timeout_input.value),
-                output: this.render_checkbox.checked};
+        return Object.assign({timeout_multiplier: parseFloat(this.timeout_input.value),
+                output: this.render_checkbox.checked}, testharness_properties);
     },
 
     get_use_regex: function() {
@@ -840,4 +840,6 @@ window.completion_callback = function(tests, status) {
 };
 
 window.addEventListener("DOMContentLoaded", setup, false);
+
+window.VisualOutput = VisualOutput;
 })();


### PR DESCRIPTION
- Enhancement: Allow `runnerjs`'  setting of `window.testharness_properties` to take into account any preexisting `window.testharness_properties` (as injected by a parent frame)
- Enhancement: Expose `runner.js`' `VisualOutput` globally so that a parent frame can monkey-patch

(FWIW, my specific interest with exposing `VisualOutput` is to add links to our `.any.js`-based polyfill version of each test file; see https://github.com/w3c/web-platform-tests/issues/5133 .)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wpt-tools/203)
<!-- Reviewable:end -->